### PR TITLE
AFTER SUBMISSION: Moved ReadLine() method to make jokes flow better

### DIFF
--- a/ChuckNorrisJokes/Program.cs
+++ b/ChuckNorrisJokes/Program.cs
@@ -16,15 +16,15 @@ namespace ChuckNorrisJokes
             Introduction();
             Program program = new Program();
             await program.getChuckNorrisJokes();
-            Console.WriteLine("\n\n If you would like a new joke, press Enter and then 'J' \n");
+            Console.WriteLine("\n\n If you would like a new joke, press 'J' \n");
             do
             {
                 await program.getChuckNorrisJokes();
             } while (Console.ReadKey(true).Key == ConsoleKey.J);
+            Console.ReadLine();
         }
 
         /// <summary>
-        ///
         /// Sets a string response variable to retrieve parsed data via GET request and converts this data into a string by GetStringAsync which returns the Task.
         /// The await handles the Task object to return the string into the declaraed response variable.
         /// Deserialises the JSON data into the variable ChuckNorrisJoke.
@@ -38,15 +38,11 @@ namespace ChuckNorrisJokes
             var ChuckNorrisJoke = JsonConvert.DeserializeObject<Jokes>(response);
 
             Console.WriteLine(ChuckNorrisJoke.value);
-
-            Console.ReadLine();
-
         }
 
         /// <summary>
         /// Introduction for the start of the console applicaiton, which uses a message box to engage with the client for confirmation as to whether they want to proceed with the application.
         /// </summary>
-        ///
         public static void Introduction()
         {
             Console.WriteLine("Are you ready for Chuck Norris jokes? \n");


### PR DESCRIPTION
Removed the ReadLine() method in the getChuckNorrisJokes() task and placed it under Main. This means the app flows quicker to the next joke without the need to skip responses by entering. The jokes appear on the next line. Also cleaned up code by removing unnecessary line breaks.

**Note, all after-submission (deadline) commits will be kept in the Develop branch.**